### PR TITLE
Address feedback on MemberMatters PR

### DIFF
--- a/memberportal/api_admin_tools/views.py
+++ b/memberportal/api_admin_tools/views.py
@@ -580,6 +580,8 @@ class MemberProfile(APIView):
         member.profile.screen_name = body.get("screenName")
         member.profile.vehicle_registration_plate = body.get("vehicleRegistrationPlate")
         member.profile.exclude_from_email_export = body.get("excludeFromEmailExport")
+        if config.ENABLE_PRONOUNS:
+            member.profile.preferred_pronouns = body.get("pronouns")
 
         member.save()
         member.profile.save()

--- a/memberportal/api_general/views.py
+++ b/memberportal/api_general/views.py
@@ -61,6 +61,7 @@ class GetConfig(APIView):
                 "footer": config.SMS_FOOTER,
             },
             "enableStatsPage": config.ENABLE_STATS_PAGE,
+            "enablePronouns": config.ENABLE_PRONOUNS,
         }
 
         keys = {"stripePublishableKey": config.STRIPE_PUBLISHABLE_KEY}
@@ -408,6 +409,9 @@ class ProfileDetail(generics.GenericAPIView):
             "permissions": {"staff": user.is_staff},
         }
 
+        if config.ENABLE_PRONOUNS:
+            response["pronouns"] = p.preferred_pronouns
+
         return Response(response)
 
     def put(self, request):
@@ -443,6 +447,8 @@ class ProfileDetail(generics.GenericAPIView):
         p.phone = body.get("phone")
         p.screen_name = body.get("screenName")
         p.vehicle_registration_plate = body.get("vehicleRegistrationPlate")
+        if config.ENABLE_PRONOUNS:
+            p.preferred_pronouns = body.get("pronouns")
 
         request.user.save()
         p.save()
@@ -664,7 +670,7 @@ class Register(APIView):
             first_name=body.get("firstName"),
             last_name=body.get("lastName"),
             screen_name=body.get("screenName"),
-            preferred_pronouns=body.get("preferred_pronouns"),
+            preferred_pronouns=body.get("pronouns"),
             phone=body.get("mobile"),
             vehicle_registration_plate=body.get("vehicleRegistrationPlate"),
         )

--- a/memberportal/membermatters/constance_config.py
+++ b/memberportal/membermatters/constance_config.py
@@ -20,6 +20,10 @@ CONSTANCE_CONFIG = {
         "",
         "A site wide banner that can display useful information. Leave empty to turn off.",
     ),
+    "ENABLE_PRONOUNS": (
+      True,
+      "Enable optional pronoun fields in profiles.",
+    ),
     # Email config
     "EMAIL_SYSADMIN": (
         "example@example.com",
@@ -401,6 +405,7 @@ CONSTANCE_CONFIG_FIELDSETS = OrderedDict(
                 "SITE_NAME",
                 "SITE_OWNER",
                 "SITE_LOCALE_CURRENCY",
+                "ENABLE_PRONOUNS",
                 "GOOGLE_ANALYTICS_MEASUREMENT_ID",
                 "SITE_BANNER",
                 "METRICS_INTERVAL",

--- a/memberportal/membermatters/constance_config.py
+++ b/memberportal/membermatters/constance_config.py
@@ -21,8 +21,8 @@ CONSTANCE_CONFIG = {
         "A site wide banner that can display useful information. Leave empty to turn off.",
     ),
     "ENABLE_PRONOUNS": (
-      True,
-      "Enable optional pronoun fields in profiles.",
+        True,
+        "Enable optional pronoun fields in profiles.",
     ),
     # Email config
     "EMAIL_SYSADMIN": (

--- a/memberportal/profile/models.py
+++ b/memberportal/profile/models.py
@@ -339,7 +339,7 @@ class Profile(ExportModelOperationsMixin("profile"), models.Model):
     first_name = models.CharField("First Name", max_length=30)
     last_name = models.CharField("Last Name", max_length=30)
     preferred_pronouns = models.CharField(
-        "Preferred Pronouns", blank=True, null=True, max_length=30
+        "Pronouns", blank=True, null=True, max_length=30
     )
     phone_regex = RegexValidator(
         regex=r"^\+?1?\d{9,15}$",
@@ -518,7 +518,7 @@ class Profile(ExportModelOperationsMixin("profile"), models.Model):
         Returns a user's profile with a basic amount of info.
         :return: {}
         """
-        return {
+        data = {
             "id": self.user.id,
             "admin": self.user.is_staff,
             "email": self.user.email,
@@ -560,6 +560,9 @@ class Profile(ExportModelOperationsMixin("profile"), models.Model):
             },
             "subscriptionStatus": self.subscription_status,
         }
+        if config.ENABLE_PRONOUNS:
+            data["pronouns"] = self.preferred_pronouns
+        return data
 
     def get_access_permissions(self, ignore_user_state=False):
         """

--- a/src-frontend/src/components/Account/RegistrationCard.vue
+++ b/src-frontend/src/components/Account/RegistrationCard.vue
@@ -68,10 +68,11 @@
               ]"
             />
             <q-input
-              v-model="form.preferred_pronouns"
+              v-if="features?.enablePronouns"
+              v-model="form.pronouns"
               class="col-12 col-sm-6"
               filled
-              :label="$t('form.preferred_pronouns')"
+              :label="$t('form.pronouns')"
             />
             <q-input
               v-model="form.mobile"

--- a/src-frontend/src/components/AdminTools/ManageMember.vue
+++ b/src-frontend/src/components/AdminTools/ManageMember.vue
@@ -202,15 +202,21 @@
                 </q-input>
 
                 <q-input
-                  v-model="profileForm.preferred_pronouns"
+                  v-if="
+                    features?.enablePronouns
+                  "
+                  v-model="profileForm.pronouns"
                   outlined
                   :debounce="debounceLength"
-                  :label="$t('form.preferred_pronouns')"
-                  @update:model-value="saveChange('preferred_pronouns')"
+                  :label="$t('form.pronouns')"
+                  :rules="[
+                    (val) => validateMax30(val) || $t('validation.max30'),
+                  ]"
+                  @update:model-value="saveChange('pronouns')"
                 >
                   <template #append>
                     <saved-notification
-                      :success="saved.preferred_pronouns"
+                      :success="saved.pronouns"
                       :error="saved.error"
                     />
                   </template>
@@ -1418,6 +1424,7 @@ export default defineComponent({
         rfidCard: '',
         firstName: '',
         lastName: '',
+        pronouns: '',
         phone: '',
         screenName: '',
         vehicleRegistrationPlate: '',
@@ -1430,6 +1437,7 @@ export default defineComponent({
         rfidCard: false,
         firstName: false,
         lastName: false,
+        pronouns: false,
         phone: false,
         screenName: false,
         vehicleRegistrationPlate: false,
@@ -1466,6 +1474,7 @@ export default defineComponent({
       this.profileForm.rfidCard = this.selectedMember.rfid;
       this.profileForm.firstName = this.selectedMember.name.first;
       this.profileForm.lastName = this.selectedMember.name.last;
+      this.profileForm.pronouns = this.selectedMember.pronouns;
       this.profileForm.phone = this.selectedMember.phone;
       this.profileForm.screenName = this.selectedMember.screenName;
       this.profileForm.vehicleRegistrationPlate =

--- a/src-frontend/src/components/ProfileForm.vue
+++ b/src-frontend/src/components/ProfileForm.vue
@@ -38,22 +38,6 @@
       </q-input>
 
       <q-input
-        v-model="form.preferred_pronouns"
-        outlined
-        :debounce="debounceLength"
-        :label="$t('form.preferred_pronouns')"
-        @update:model-value="saveChange('preferred_pronouns')"
-      >
-        <template v-slot:append>
-          <saved-notification
-            :success="saved.preferred_pronouns"
-            show-text
-            :error="saved.error"
-          />
-        </template>
-      </q-input>
-
-      <q-input
         v-model="form.lastName"
         outlined
         :debounce="debounceLength"
@@ -66,6 +50,24 @@
         <template v-slot:append>
           <saved-notification
             :success="saved.lastName"
+            show-text
+            :error="saved.error"
+          />
+        </template>
+      </q-input>
+
+      <q-input
+        v-if="features?.enablePronouns"
+        v-model="form.pronouns"
+        outlined
+        :debounce="debounceLength"
+        :label="$t('form.pronouns')"
+        :rules="[(val) => validateMax30(val) || $t('validation.max30')]"
+        @update:model-value="saveChange('pronouns')"
+      >
+        <template v-slot:append>
+          <saved-notification
+            :success="saved.pronouns"
             show-text
             :error="saved.error"
           />
@@ -149,6 +151,7 @@ export default {
         email: '',
         firstName: '',
         lastName: '',
+        pronouns: '',
         phone: '',
         screenName: '',
         vehicleRegistrationPlate: '',
@@ -160,6 +163,7 @@ export default {
         email: false,
         firstName: false,
         lastName: false,
+        pronouns: false,
         phone: false,
         screenName: false,
         vehicleRegistrationPlate: false,
@@ -172,6 +176,7 @@ export default {
       this.form.email = this.profile.email;
       this.form.firstName = this.profile.firstName;
       this.form.lastName = this.profile.lastName;
+      this.form.pronouns = this.profile.pronouns;
       this.form.phone = this.profile.phone;
       this.form.screenName = this.profile.screenName;
       this.form.vehicleRegistrationPlate =

--- a/src-frontend/src/i18n/en-AU/index.ts
+++ b/src-frontend/src/i18n/en-AU/index.ts
@@ -247,6 +247,7 @@ export default {
     rfidCard: 'RFID Card',
     firstName: 'First Name *',
     lastName: 'Last Name *',
+    pronouns: 'Pronouns',
     mobile: 'Mobile Number *',
     screenName: 'Screen / Nickname *',
     date: 'Date',


### PR DESCRIPTION
This PR fixes the feedback given on https://github.com/membermatters/MemberMatters/pull/342 , allows pronoun data to flow back and forth from the profile pages.

I've also changed "Preferred pronouns" to just "Pronouns" – it's a small change but that's the better language to use these days (saying 'preferred' gives people more of a reason to just ignore them if they want to, and argue that's okay, etc).